### PR TITLE
[MCKIN-8918] Backport retirement API

### DIFF
--- a/api/users.rb
+++ b/api/users.rb
@@ -199,8 +199,14 @@ post "#{APIPREFIX}/users/:user_id/social_stats" do |user_id|
 end
 
 post "#{APIPREFIX}/users/:user_id/retire" do |user_id|
-  return {}.to_json if not params["retired_username"]
-  user = User.find_by!(external_id: user_id)
+  if not params["retired_username"]
+    error 500, {message: "Missing retired_username param."}.to_json
+  end
+  begin
+    user = User.find_by(external_id: user_id)
+  rescue Mongoid::Errors::DocumentNotFound
+    error 404, {message: "User not found."}.to_json
+  end
   user.update_attribute(:email, "")
   user.update_attribute(:notification_ids, [])
   user.update_attribute(:read_states, [])

--- a/api/users.rb
+++ b/api/users.rb
@@ -198,3 +198,13 @@ post "#{APIPREFIX}/users/:user_id/social_stats" do |user_id|
   _user_social_stats(user_id, params)
 end
 
+post "#{APIPREFIX}/users/:user_id/retire" do |user_id|
+  return {}.to_json if not params["retired_username"]
+  user = User.find_by!(external_id: user_id)
+  user.update_attribute(:email, "")
+  user.update_attribute(:notification_ids, [])
+  user.update_attribute(:read_states, [])
+  user.unsubscribe_all
+  user.retire_all_comments(params["retired_username"])
+  user.update_attribute(:username, params["retired_username"])
+end

--- a/api/users.rb
+++ b/api/users.rb
@@ -211,6 +211,7 @@ post "#{APIPREFIX}/users/:user_id/retire" do |user_id|
   user.update_attribute(:notification_ids, [])
   user.update_attribute(:read_states, [])
   user.unsubscribe_all
-  user.retire_all_comments(params["retired_username"])
+  user.retire_all_content(params["retired_username"])
   user.update_attribute(:username, params["retired_username"])
+  user.save
 end

--- a/models/comment.rb
+++ b/models/comment.rb
@@ -21,6 +21,7 @@ class Comment < Content
   field :at_position_list, type: Array, default: []
   field :sk, type: String, default: nil
   field :child_count, type: Integer
+  field :retired_username, type: String, default: nil
 
   index({author_id: 1, course_id: 1})
   index({_type: 1, comment_thread_id: 1, author_id: 1, updated_at: 1})
@@ -42,7 +43,7 @@ class Comment < Content
   belongs_to :comment_thread, index: true
   belongs_to :author, class_name: 'User', index: true
 
-  attr_accessible :body, :course_id, :anonymous, :anonymous_to_peers, :endorsed, :endorsement
+  attr_accessible :body, :course_id, :anonymous, :anonymous_to_peers, :endorsed, :endorsement, :retired_username
 
   validates_presence_of :comment_thread, autosave: false
   validates_presence_of :body

--- a/models/comment_thread.rb
+++ b/models/comment_thread.rb
@@ -27,6 +27,7 @@ class CommentThread < Content
   field :last_activity_at, type: Time
   field :group_id, type: Integer
   field :pinned, type: Boolean
+  field :retired_username, type: String, default: nil
 
   index({author_id: 1, course_id: 1})
 
@@ -53,7 +54,7 @@ class CommentThread < Content
   has_many :comments, dependent: :destroy # Use destroy to invoke callback on the top-level comments
   has_many :activities, autosave: true
 
-  attr_accessible :title, :body, :course_id, :commentable_id, :anonymous, :anonymous_to_peers, :closed, :thread_type
+  attr_accessible :title, :body, :course_id, :commentable_id, :anonymous, :anonymous_to_peers, :closed, :thread_type, :retired_username
 
   validates_presence_of :thread_type
   validates_presence_of :context

--- a/models/concerns/searchable.rb
+++ b/models/concerns/searchable.rb
@@ -20,16 +20,35 @@ module Searchable
       self.as_json(options.merge root: false)
     end
 
+    # Class-level variable which toggles all ES callbacks.  This should be an instance-level variable,
+    # ideally, but it took us too long to get that working correctly.  This should be safe because forums
+    # code runs single-threaded.
+    @@enable_es = true
+
+    # The caller may opt to temporarily disable ES callbacks by using this toggle, e.g.:
+    #
+    #   comment.enable_es(false)
+    #   comment.update!(data)
+    #   comment.enable_es(true)
+    #
+    def enable_es(x)
+      @@enable_es = x
+    end
+
+    def is_es_enabled
+      @@enable_es
+    end
+
     private # all methods below are private
 
     def index_document
-      __elasticsearch__.index_document if CommentService.search_enabled?
+      __elasticsearch__.index_document if CommentService.search_enabled? && is_es_enabled
     end
 
     # This is named in this manner to prevent collisions with Mongoid's update_document method.
     def update_indexed_document
       begin
-        __elasticsearch__.update_document if CommentService.search_enabled?
+        __elasticsearch__.update_document if CommentService.search_enabled? && is_es_enabled
       rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
         # If attempting to update a document that doesn't exist, just continue.
         logger.warn "ES update failed upon update_document - not found."
@@ -38,7 +57,7 @@ module Searchable
 
     def delete_document
       begin
-        __elasticsearch__.delete_document if CommentService.search_enabled?
+        __elasticsearch__.delete_document if CommentService.search_enabled? && is_es_enabled
       rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
         # If attempting to delete a document that doesn't exist, just continue.
         logger.warn "ES delete failed upon delete_document - not found."

--- a/models/concerns/searchable.rb
+++ b/models/concerns/searchable.rb
@@ -1,3 +1,8 @@
+require 'logger'
+
+logger = Logger.new(STDOUT)
+logger.level = Logger::WARN
+
 module Searchable
   extend ActiveSupport::Concern
 
@@ -23,11 +28,21 @@ module Searchable
 
     # This is named in this manner to prevent collisions with Mongoid's update_document method.
     def update_indexed_document
-      __elasticsearch__.update_document if CommentService.search_enabled?
+      begin
+        __elasticsearch__.update_document if CommentService.search_enabled?
+      rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
+        # If attempting to update a document that doesn't exist, just continue.
+        logger.warn "ES update failed upon update_document - not found."
+      end
     end
 
     def delete_document
-      __elasticsearch__.delete_document ignore: 404 if CommentService.search_enabled?
+      begin
+        __elasticsearch__.delete_document if CommentService.search_enabled?
+      rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
+        # If attempting to delete a document that doesn't exist, just continue.
+        logger.warn "ES delete failed upon delete_document - not found."
+      end
     end
   end
 end

--- a/models/constants.rb
+++ b/models/constants.rb
@@ -28,3 +28,6 @@ USERNAME = "username".freeze
 EXTERNAL_ID = "external_id".freeze
 COMMENT = "comment".freeze
 THREAD = "thread".freeze
+
+RETIRED_TITLE = "<removed_text>".freeze
+RETIRED_BODY = "<removed_text>".freeze

--- a/models/constants.rb
+++ b/models/constants.rb
@@ -29,5 +29,5 @@ EXTERNAL_ID = "external_id".freeze
 COMMENT = "comment".freeze
 THREAD = "thread".freeze
 
-RETIRED_TITLE = "<removed_text>".freeze
-RETIRED_BODY = "<removed_text>".freeze
+RETIRED_TITLE = "[deleted]".freeze
+RETIRED_BODY = "[deleted]".freeze

--- a/models/content.rb
+++ b/models/content.rb
@@ -63,7 +63,7 @@ class Content
 
   def self.summary what
     #take a hash of criteria (what) and return a hash of hashes
-    #of total users, votes, comments, endorsements, 
+    #of total users, votes, comments, endorsements,
 
     answer = {}
     vote_count = 0
@@ -101,6 +101,6 @@ class Content
 
   def set_username
     # avoid having to look this attribute up later, since it does not change
-    self.author_username = author.username
+    self.author_username = self.retired_username ? self.retired_username : author.username
   end
 end

--- a/models/user.rb
+++ b/models/user.rb
@@ -163,9 +163,9 @@ class User
     if comment._type == "CommentThread"
       data[:title] = RETIRED_TITLE
     end
-    comment.enable_es(false)
-    comment.update!(data)
-    comment.enable_es(true)
+    comment.without_es do
+      comment.update!(data)
+    end
     # Craft a bulk action for elasticsearch.  This is a little bit of low-level boilerplate which is
     # normally handled by the elasticsearch-rails package, but the high-level API bindings don't include
     # support for bulk requests so we need to do the dirty work ourselves.

--- a/models/user.rb
+++ b/models/user.rb
@@ -148,6 +148,12 @@ class User
     user_comments
   end
 
+  def all_comment_threads
+    # Returns all comment threads authored by this user.
+    user_comment_threads = CommentThread.where(author_id: self._id.to_s)
+    user_comment_threads
+  end
+
   def retire_comment(comment, retired_username)
     # Retire a single comment.
     comment.update(retired_username: retired_username)
@@ -158,10 +164,12 @@ class User
     comment.save
   end
 
-  def retire_all_comments(retired_username)
-    # Retire all comments authored by this user.
+  def retire_all_content(retired_username)
+    # Retire all content authored by this user.
     user_comments = all_comments
-    user_comments.each {|comment| retire_comment(comment, retired_username)}
+    user_comment_threads = all_comment_threads
+    user_content = all_comments + all_comment_threads
+    user_content.each {|comment| retire_comment(comment, retired_username)}
   end
 
   def mark_as_read(thread)

--- a/models/user.rb
+++ b/models/user.rb
@@ -22,6 +22,9 @@ class User
 
   index( {external_id: 1}, {unique: true, background: true} )
 
+  logger = Logger.new(STDOUT)
+  logger.level = Logger::WARN
+
   def subscriptions_as_source
     Subscription.where(source_id: id.to_s, source_type: self.class.to_s)
   end
@@ -131,6 +134,34 @@ class User
     subscription = Subscription.where(subscriber_id: self._id.to_s, source_id: source._id.to_s, source_type: source.class.to_s).first
     subscription.destroy if subscription
     subscription
+  end
+
+  def unsubscribe_all
+    # Unsubscribe this user from all their subscribed threads across all courses.
+    sub_threads = subscribed_threads
+    sub_threads.each {|sub_id| unsubscribe(sub_id) }
+  end
+
+  def all_comments
+    # Returns all comments authored by this user.
+    user_comments = Comment.where(author_id: self._id.to_s)
+    user_comments
+  end
+
+  def retire_comment(comment, retired_username)
+    # Retire a single comment.
+    comment.update(retired_username: retired_username)
+    comment.update(body: RETIRED_BODY)
+    if comment._type == "CommentThread"
+      comment.update(title: RETIRED_TITLE)
+    end
+    comment.save
+  end
+
+  def retire_all_comments(retired_username)
+    # Retire all comments authored by this user.
+    user_comments = all_comments
+    user_comments.each {|comment| retire_comment(comment, retired_username)}
   end
 
   def mark_as_read(thread)

--- a/models/user.rb
+++ b/models/user.rb
@@ -155,13 +155,29 @@ class User
   end
 
   def retire_comment(comment, retired_username)
-    # Retire a single comment.
-    comment.update(retired_username: retired_username)
-    comment.update(body: RETIRED_BODY)
+    # Retire a single comment and return a bulk action for elasticsearch.
+    data = {
+        retired_username: retired_username,
+        body: RETIRED_BODY
+    }
     if comment._type == "CommentThread"
-      comment.update(title: RETIRED_TITLE)
+      data[:title] = RETIRED_TITLE
     end
-    comment.save
+    comment.enable_es(false)
+    comment.update!(data)
+    comment.enable_es(true)
+    # Craft a bulk action for elasticsearch.  This is a little bit of low-level boilerplate which is
+    # normally handled by the elasticsearch-rails package, but the high-level API bindings don't include
+    # support for bulk requests so we need to do the dirty work ourselves.
+    data[:author_username] = retired_username
+    {
+      update: {
+        _index: Content::ES_INDEX_NAME,
+        _type: comment.__elasticsearch__.document_type,
+        _id: comment._id,
+        data: { doc: data }
+      }
+    }
   end
 
   def retire_all_content(retired_username)
@@ -169,7 +185,14 @@ class User
     user_comments = all_comments
     user_comment_threads = all_comment_threads
     user_content = all_comments + all_comment_threads
-    user_content.each {|comment| retire_comment(comment, retired_username)}
+    # Retire each comment one at a time, deferring any ES updates.
+    bulk_data = user_content.map {|comment| retire_comment(comment, retired_username)}
+    # Finally, update ES with all the comment changes in one bulk HTTP request.  This is a bit of a time
+    # bomb since it might cause the request payload to blow up for that one user with 100k forum posts,
+    # but the failure mode before bulking was undeniably worse so at least we're making progress.  ES
+    # docs claim that a 10MB payload is a good starting point for a bulk request, which for our use case
+    # means blanking out about 36k forum posts.  That's a lot of flame wars for one user!
+    Elasticsearch::Model.client.bulk(body: bulk_data)
   end
 
   def mark_as_read(thread)

--- a/models/user.rb
+++ b/models/user.rb
@@ -185,14 +185,19 @@ class User
     user_comments = all_comments
     user_comment_threads = all_comment_threads
     user_content = all_comments + all_comment_threads
-    # Retire each comment one at a time, deferring any ES updates.
-    bulk_data = user_content.map {|comment| retire_comment(comment, retired_username)}
-    # Finally, update ES with all the comment changes in one bulk HTTP request.  This is a bit of a time
-    # bomb since it might cause the request payload to blow up for that one user with 100k forum posts,
-    # but the failure mode before bulking was undeniably worse so at least we're making progress.  ES
-    # docs claim that a 10MB payload is a good starting point for a bulk request, which for our use case
-    # means blanking out about 36k forum posts.  That's a lot of flame wars for one user!
-    Elasticsearch::Model.client.bulk(body: bulk_data)
+    # We must avoid sending empty bulk requests, so we wrap the following in a conditional.  Otherwise,
+    # Elasticsearch::Model.client.bulk() will blindly pass along an empty string to the bulk API
+    # endpoint which causes 400s and cryptic error messages.
+    unless user_content.empty?
+      # Retire each comment one at a time, deferring any ES updates.
+      bulk_data = user_content.map {|comment| retire_comment(comment, retired_username)}
+      # Finally, update ES with all the comment changes in one bulk HTTP request.  This is a bit of a time
+      # bomb since it might cause the request payload to blow up for that one user with 100k forum posts,
+      # but the failure mode before bulking was undeniably worse so at least we're making progress.  ES
+      # docs claim that a 10MB payload is a good starting point for a bulk request, which for our use case
+      # means blanking out about 36k forum posts.  That's a lot of flame wars for one user!
+      Elasticsearch::Model.client.bulk(body: bulk_data)
+    end
   end
 
   def mark_as_read(thread)

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -740,5 +740,56 @@ describe "app" do
         end
       end
     end
+
+    describe "POST /api/v1/users/:user_id/retire" do
+
+      before :each do
+        User.all.delete
+        Content.all.delete
+        init_without_subscriptions
+      end
+
+      it "retires a user and all the user's data" do
+        retired_username = "retired_user_ABCD1234"
+        user = User.where(external_id: '1').first
+        # User should have original username.
+        expect(user.username).to eq('user1')
+        # User should be subscribed to threads.
+        get "/api/v1/users/#{user.external_id}/subscribed_threads", course_id: "1"
+        expect(last_response).to be_ok
+        expect(JSON.parse(last_response.body)['thread_count']).to eq(1)
+        get "/api/v1/users/#{user.external_id}/subscribed_threads", course_id: "2"
+        expect(last_response).to be_ok
+        body = JSON.parse(last_response.body)
+        expect(body['thread_count']).to eq(1)
+        comment_id = body['collection'][0]['id']
+
+        # Retire the user.
+        post "/api/v1/users/#{user.external_id}/retire", retired_username: retired_username
+        expect(last_response).to be_ok
+
+        user.reload
+        # User should have retired username.
+        expect(user.username).to eq(retired_username)
+        # User should have blank email.
+        expect(user.email).to eq('')
+        # User should be subscribed to no threads.
+        get "/api/v1/users/#{user.external_id}/subscribed_threads", course_id: "1"
+        expect(last_response).to be_ok
+        expect(JSON.parse(last_response.body)['thread_count']).to eq(0)
+        get "/api/v1/users/#{user.external_id}/subscribed_threads", course_id: "2"
+        expect(last_response).to be_ok
+        expect(JSON.parse(last_response.body)['thread_count']).to eq(0)
+        # User's comments should be blanked out.
+        comments = user.all_comments
+        comments.each do |single_comment|
+          if single_comment._type == 'CommentThread'
+            expect(single_comment.title).to match(RETIRED_TITLE)
+          end
+          expect(single_comment.body).to match(RETIRED_BODY)
+          expect(single_comment.author_username).to match(retired_username)
+        end
+      end
+    end
   end
 end

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -742,80 +742,128 @@ describe "app" do
     end
 
     describe "POST /api/v1/users/:user_id/retire" do
+      # The Use Retirement code paths are sensitive to the behavior of ES, so
+      # we must test with it turned on.
+      include_context 'search_enabled'
 
-      before :each do
-        User.all.delete
-        Content.all.delete
-        init_without_subscriptions
-      end
+      describe "with an inactive forums user," do
+        before :each do
+          User.all.delete
+          Content.all.delete
+          create_test_user(1)
+          # no threads/posts/commentables are set up at all.
+        end
 
-      it "attempts to retire a user without sending retired_username" do
-        post "/api/v1/users/1/retire"
-        expect(last_response.status).to eq(500)
-      end
+        it "retires a user and all the user's data" do
+          retired_username = "retired_username_ABCD1234"
+          user = User.where(external_id: '1').first
+          # User should have original username.
+          expect(user.username).to eq('user1')
+          # User should not be subscribed to threads.
+          get "/api/v1/users/#{user.external_id}/subscribed_threads", course_id: "1"
+          expect(last_response).to be_ok
+          expect(JSON.parse(last_response.body)['thread_count']).to eq(0)
+          get "/api/v1/users/#{user.external_id}/subscribed_threads", course_id: "2"
+          expect(last_response).to be_ok
+          expect(JSON.parse(last_response.body)['thread_count']).to eq(0)
 
-      it "attempts to retire a user with no subscribed threads" do
-        retired_username = "retired_user_test"
-        post "/api/v1/users/2/retire", retired_username: retired_username
-        expect(last_response).to be_ok
-        # User's comments should be blanked out.
-        user = User.where(external_id: '2').first
-        comments = user.all_comments + user.all_comment_threads
-        expect(comments.count).should_not eq(0)
-        comments.each do |single_comment|
-          if single_comment._type == 'CommentThread'
-            expect(single_comment.title).to match(RETIRED_TITLE)
-          end
-          expect(single_comment.body).to match(RETIRED_BODY)
-          expect(single_comment.author_username).to match(retired_username)
+          # Retire the user.
+          post "/api/v1/users/#{user.external_id}/retire", retired_username: retired_username
+          expect(last_response).to be_ok
+
+          user.reload
+          # User should have retired username.
+          expect(user.username).to eq(retired_username)
+          # User should have blank email.
+          expect(user.email).to eq('')
+          # User should be subscribed to no threads.
+          get "/api/v1/users/#{user.external_id}/subscribed_threads", course_id: "1"
+          expect(last_response).to be_ok
+          expect(JSON.parse(last_response.body)['thread_count']).to eq(0)
+          get "/api/v1/users/#{user.external_id}/subscribed_threads", course_id: "2"
+          expect(last_response).to be_ok
+          expect(JSON.parse(last_response.body)['thread_count']).to eq(0)
+          # User's comments should be blanked out.
+          comments = user.all_comments + user.all_comment_threads
+          expect(comments.count).to eq(0)
         end
       end
 
-      it "attempts to retire a non-existent user" do
-        post "/api/v1/users/1234/retire", retired_username: "retired_user_test"
-        expect(last_response.status).to eq(404)
-      end
+      describe "with an active forums user," do
+        before :each do
+          User.all.delete
+          Content.all.delete
+          init_without_subscriptions
+        end
 
-      it "retires a user and all the user's data" do
-        retired_username = "retired_username_ABCD1234"
-        user = User.where(external_id: '1').first
-        # User should have original username.
-        expect(user.username).to eq('user1')
-        # User should be subscribed to threads.
-        get "/api/v1/users/#{user.external_id}/subscribed_threads", course_id: "1"
-        expect(last_response).to be_ok
-        expect(JSON.parse(last_response.body)['thread_count']).to eq(1)
-        get "/api/v1/users/#{user.external_id}/subscribed_threads", course_id: "2"
-        expect(last_response).to be_ok
-        body = JSON.parse(last_response.body)
-        expect(body['thread_count']).to eq(1)
-        comment_id = body['collection'][0]['id']
+        it "attempts to retire a user without sending retired_username" do
+          post "/api/v1/users/1/retire"
+          expect(last_response.status).to eq(500)
+        end
 
-        # Retire the user.
-        post "/api/v1/users/#{user.external_id}/retire", retired_username: retired_username
-        expect(last_response).to be_ok
-
-        user.reload
-        # User should have retired username.
-        expect(user.username).to eq(retired_username)
-        # User should have blank email.
-        expect(user.email).to eq('')
-        # User should be subscribed to no threads.
-        get "/api/v1/users/#{user.external_id}/subscribed_threads", course_id: "1"
-        expect(last_response).to be_ok
-        expect(JSON.parse(last_response.body)['thread_count']).to eq(0)
-        get "/api/v1/users/#{user.external_id}/subscribed_threads", course_id: "2"
-        expect(last_response).to be_ok
-        expect(JSON.parse(last_response.body)['thread_count']).to eq(0)
-        # User's comments should be blanked out.
-        comments = user.all_comments + user.all_comment_threads
-        expect(comments.count).should_not eq(0)
-        comments.each do |single_comment|
-          if single_comment._type == 'CommentThread'
-            expect(single_comment.title).to match(RETIRED_TITLE)
+        it "attempts to retire a user with no subscribed threads" do
+          retired_username = "retired_user_test"
+          post "/api/v1/users/2/retire", retired_username: retired_username
+          expect(last_response).to be_ok
+          # User's comments should be blanked out.
+          user = User.where(external_id: '2').first
+          comments = user.all_comments + user.all_comment_threads
+          expect(comments.count).should_not eq(0)
+          comments.each do |single_comment|
+            if single_comment._type == 'CommentThread'
+              expect(single_comment.title).to match(RETIRED_TITLE)
+            end
+            expect(single_comment.body).to match(RETIRED_BODY)
+            expect(single_comment.author_username).to match(retired_username)
           end
-          expect(single_comment.body).to match(RETIRED_BODY)
-          expect(single_comment.author_username).to match(retired_username)
+        end
+
+        it "attempts to retire a non-existent user" do
+          post "/api/v1/users/1234/retire", retired_username: "retired_user_test"
+          expect(last_response.status).to eq(404)
+        end
+
+        it "retires the user and all the user's data" do
+          retired_username = "retired_username_ABCD1234"
+          user = User.where(external_id: '1').first
+          # User should have original username.
+          expect(user.username).to eq('user1')
+          # User should be subscribed to threads.
+          get "/api/v1/users/#{user.external_id}/subscribed_threads", course_id: "1"
+          expect(last_response).to be_ok
+          expect(JSON.parse(last_response.body)['thread_count']).to eq(1)
+          get "/api/v1/users/#{user.external_id}/subscribed_threads", course_id: "2"
+          expect(last_response).to be_ok
+          body = JSON.parse(last_response.body)
+          expect(body['thread_count']).to eq(1)
+          comment_id = body['collection'][0]['id']
+
+          # Retire the user.
+          post "/api/v1/users/#{user.external_id}/retire", retired_username: retired_username
+          expect(last_response).to be_ok
+
+          user.reload
+          # User should have retired username.
+          expect(user.username).to eq(retired_username)
+          # User should have blank email.
+          expect(user.email).to eq('')
+          # User should be subscribed to no threads.
+          get "/api/v1/users/#{user.external_id}/subscribed_threads", course_id: "1"
+          expect(last_response).to be_ok
+          expect(JSON.parse(last_response.body)['thread_count']).to eq(0)
+          get "/api/v1/users/#{user.external_id}/subscribed_threads", course_id: "2"
+          expect(last_response).to be_ok
+          expect(JSON.parse(last_response.body)['thread_count']).to eq(0)
+          # User's comments should be blanked out.
+          comments = user.all_comments + user.all_comment_threads
+          expect(comments.count).should_not eq(0)
+          comments.each do |single_comment|
+            if single_comment._type == 'CommentThread'
+              expect(single_comment.title).to match(RETIRED_TITLE)
+            end
+            expect(single_comment.body).to match(RETIRED_BODY)
+            expect(single_comment.author_username).to match(retired_username)
+          end
         end
       end
     end

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -12,37 +12,37 @@ describe "app" do
     describe "POST /api/v1/users" do
       it "creates a user" do
         post "/api/v1/users", id: "100", username: "user100"
-        last_response.should be_ok
+        expect(last_response).to be_ok
         user = User.find_by(external_id: "100")
-        user.username.should == "user100"
+        expect(user.username).to eq("user100")
       end
       it "returns error when id / username already exists" do
         post "/api/v1/users", id: "1", username: "user100"
-        last_response.status.should == 400
+        expect(last_response.status).to eq(400)
         post "/api/v1/users", id: "100", username: "user1"
-        last_response.status.should == 400
+        expect(last_response.status).to eq(400)
       end
     end
     describe "PUT /api/v1/users/:user_id" do
       it "updates user information" do
         put "/api/v1/users/1", username: "new_user_1"
-        last_response.should be_ok
+        expect(last_response).to be_ok
         user = User.find_by("1")
-        user.username.should == "new_user_1"
+        expect(user.username).to eq("new_user_1")
       end
       it "does not update id" do
         put "/api/v1/users/1", id: "100"
-        last_response.should be_ok
+        expect(last_response).to be_ok
         user = User.find_by("1")
-        user.should_not be_nil
+        expect(user).not_to be_nil
       end
       it "returns error if user does not exist" do
         put "/api/v1/users/100", id: "100"
-        last_response.status.should == 400
+        expect(last_response.status).to eq(400)
       end
       it "returns error if new information has conflict with other users" do
         put "/api/v1/users/1", username: "user2"
-        last_response.status.should == 400
+        expect(last_response.status).to eq(400)
       end
     end
 
@@ -53,32 +53,32 @@ describe "app" do
 
       it "returns user information" do
         get "/api/v1/users/1"
-        last_response.status.should == 200
+        expect(last_response.status).to eq(200)
         res = parse(last_response.body)
         user1 = User.find_by("1")
-        res["external_id"].should == user1.external_id
-        res["username"].should == user1.username
+        expect(res["external_id"]).to eq(user1.external_id)
+        expect(res["username"]).to eq(user1.username)
       end
 
       it "returns 404 if user does not exist" do
         get "/api/v1/users/3"
-        last_response.status.should == 404
+        expect(last_response.status).to eq(404)
       end
 
       it "returns no threads when user hasn't voted" do
         get "/api/v1/users/1", complete: "true"
-        last_response.status.should == 200
+        expect(last_response.status).to eq(200)
         res = parse(last_response.body)
-        res["upvoted_ids"].should == []
+        expect(res["upvoted_ids"]).to eq([])
       end
 
       it "returns threads when user votes" do
         reader.vote(thread, :up)
 
         get "/api/v1/users/2", complete: "true"
-        last_response.status.should == 200
+        expect(last_response.status).to eq(200)
         res = parse(last_response.body)
-        res["upvoted_ids"].should == [thread.id.to_s]
+        expect(res["upvoted_ids"]).to eq([thread.id.to_s])
       end
 
       describe "Returns threads_count and comments_count" do
@@ -111,8 +111,8 @@ describe "app" do
 
           def parse_response_and_verify_counts(expected_threads, expected_comments)
              res = parse(last_response.body)
-             res["threads_count"].should == expected_threads
-             res["comments_count"].should == expected_comments
+             expect(res["threads_count"]).to eq(expected_threads)
+             expect(res["comments_count"]).to eq(expected_comments)
           end
 
           it "returns threads_count and comments_count" do
@@ -193,15 +193,15 @@ describe "app" do
 
       def thread_result(user_id, params)
         get "/api/v1/users/#{user_id}/active_threads", params
-        last_response.should be_ok
+        expect(last_response).to be_ok
         parse(last_response.body)["collection"]
       end
 
       it "requires that a course id be passed" do
         get "/api/v1/users/100/active_threads"
         # this is silly, but it is the legacy behavior
-        last_response.should be_ok
-        last_response.body.should == "{}"
+        expect(last_response).to be_ok
+        expect(last_response.body).to eq("{}")
       end
 
       context 'with standalone thread' do
@@ -227,7 +227,7 @@ describe "app" do
           results = thread_result 100, course_id: "xyz"
           # it should not include the standalone thread we created for user 100
           # not the standalone thread user 100 is a commenter on
-          results.length.should == 2
+          expect(results.length).to eq(2)
 
           # it should include the course thread owned by user 100 (t0)
           # and the course thread user 100 has a comment on (t3)
@@ -240,28 +240,28 @@ describe "app" do
         @threads["t1"].author = @users["u100"]
         @threads["t1"].save!
         rs = thread_result 100, course_id: DFLT_COURSE_ID, group_id: 42
-        rs.length.should == 2
+        expect(rs.length).to eq(2)
         @threads["t1"].group_id = 43
         @threads["t1"].save!
         rs = thread_result 100, course_id: DFLT_COURSE_ID, group_id: 42
-        rs.length.should == 1
+        expect(rs.length).to eq(1)
         @threads["t1"].group_id = 42
         @threads["t1"].save!
         rs = thread_result 100, course_id: DFLT_COURSE_ID, group_id: 42
-        rs.length.should == 2
+        expect(rs.length).to eq(2)
       end
 
       it "filters by group_ids" do
         @threads["t1"].author = @users["u100"]
         @threads["t1"].save!
         rs = thread_result 100, course_id: DFLT_COURSE_ID, group_ids: "42"
-        rs.length.should == 2
+        expect(rs.length).to eq(2)
         @threads["t1"].group_id = 43
         @threads["t1"].save!
         rs = thread_result 100, course_id: DFLT_COURSE_ID, group_ids: "42"
-        rs.length.should == 1
+        expect(rs.length).to eq(1)
         rs = thread_result 100, course_id: DFLT_COURSE_ID, group_ids: "42,43"
-        rs.length.should == 2
+        expect(rs.length).to eq(2)
       end
 
       it "does not return threads in which the user has only participated anonymously" do
@@ -272,7 +272,7 @@ describe "app" do
         @comments["t5 c1"].anonymous = true
         @comments["t5 c1"].save!
         rs = thread_result 100, course_id: "xyz"
-        rs.length.should == 1
+        expect(rs.length).to eq(1)
         check_thread_result_json(@users["u100"], @threads["t0"], rs.first)
       end
 
@@ -284,7 +284,7 @@ describe "app" do
         @threads["t9"].course_id = "zzz"
         @threads["t9"].save!
         rs = thread_result 100, course_id: "xyz"
-        rs.length.should == 9
+        expect(rs.length).to eq(9)
       end
 
       it "correctly orders results by most recent update by selected user" do
@@ -303,13 +303,13 @@ describe "app" do
         @threads["t3"].save!
         rs = thread_result 100, course_id: "xyz"
         actual_order = rs.map {|v| v["title"]}
-        actual_order.should == ["t3", "t4", "t2", "t0"]
+        expect(actual_order).to eq(["t3", "t4", "t2", "t0"])
       end
 
       context "pagination" do
         def thread_result_page (page, per_page)
           get "/api/v1/users/100/active_threads", course_id: "xyz", page: page, per_page: per_page
-          last_response.should be_ok
+          expect(last_response).to be_ok
           parse(last_response.body)
         end
 
@@ -322,20 +322,20 @@ describe "app" do
 
         it "returns single page" do
           result = thread_result_page(1, 20)
-          result["collection"].length.should == 10
-          result["num_pages"].should == 1
-          result["page"].should == 1
+          expect(result["collection"].length).to eq(10)
+          expect(result["num_pages"]).to eq(1)
+          expect(result["page"]).to eq(1)
         end
         it "returns multiple pages" do
           result = thread_result_page(1, 5)
-          result["collection"].length.should == 5
-          result["num_pages"].should == 2
-          result["page"].should == 1
+          expect(result["collection"].length).to eq(5)
+          expect(result["num_pages"]).to eq(2)
+          expect(result["page"]).to eq(1)
 
           result = thread_result_page(2, 5)
-          result["collection"].length.should == 5
-          result["num_pages"].should == 2
-          result["page"].should == 2
+          expect(result["collection"].length).to eq(5)
+          expect(result["num_pages"]).to eq(2)
+          expect(result["page"]).to eq(2)
         end
         it "orders correctly across pages" do
           expected_order = @threads.keys.reverse
@@ -345,30 +345,30 @@ describe "app" do
           num_pages.times do |i|
             page = i + 1
             result = thread_result_page(page, per_page)
-            result["collection"].length.should == (page * per_page <= @threads.length ? per_page : @threads.length % per_page)
-            result["num_pages"].should == num_pages
-            result["page"].should == page
+            expect(result["collection"].length).to eq((page * per_page <= @threads.length ? per_page : @threads.length % per_page))
+            expect(result["num_pages"]).to eq(num_pages)
+            expect(result["page"]).to eq(page)
             actual_order += result["collection"].map {|v| v["title"]}
           end
-          actual_order.should == expected_order
+          expect(actual_order).to eq(expected_order)
         end
         it "accepts negative parameters" do
           result = thread_result_page(-5, -5)
-          result["collection"].length.should == 10
-          result["num_pages"].should == 1
-          result["page"].should == 1
+          expect(result["collection"].length).to eq(10)
+          expect(result["num_pages"]).to eq(1)
+          expect(result["page"]).to eq(1)
         end
         it "accepts excessively large parameters" do
           result = thread_result_page(9999, 9999)
-          result["collection"].length.should == 10
-          result["num_pages"].should == 1
-          result["page"].should == 1
+          expect(result["collection"].length).to eq(10)
+          expect(result["num_pages"]).to eq(1)
+          expect(result["page"]).to eq(1)
         end
         it "accepts empty parameters" do
           result = thread_result_page("", "")
-          result["collection"].length.should == 10
-          result["num_pages"].should == 1
-          result["page"].should == 1
+          expect(result["collection"].length).to eq(10)
+          expect(result["num_pages"]).to eq(1)
+          expect(result["page"]).to eq(1)
         end
       end
 
@@ -378,7 +378,7 @@ describe "app" do
         thread = make_thread(user, text, course_id, "unicode_commentable")
         make_comment(user, thread, text)
         result = thread_result(user.id, course_id: course_id)
-        result.length.should == 1
+        expect(result.length).to eq(1)
         check_thread_result_json(nil, thread, result.first)
       end
 
@@ -393,7 +393,7 @@ describe "app" do
         thread = @threads["t0"]
         user = create_test_user(42)
         post "/api/v1/users/#{user.external_id}/read", source_type: "thread", source_id: thread.id
-        last_response.should be_ok
+        expect(last_response).to be_ok
         user.reload
         read_states = user.read_states.where(course_id: thread.course_id).to_a
         read_date = read_states.first.last_read_times[thread.id.to_s]

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -749,6 +749,16 @@ describe "app" do
         init_without_subscriptions
       end
 
+      it "attempts to retire a user without sending retired_username" do
+        post "/api/v1/users/1/retire"
+        expect(last_response.status).to eq(500)
+      end
+
+      it "attempts to retire a non-existent user" do
+        post "/api/v1/users/1234/retire", retired_username: "retired_user_test"
+        expect(last_response.status).to eq(404)
+      end
+
       it "retires a user and all the user's data" do
         retired_username = "retired_user_ABCD1234"
         user = User.where(external_id: '1').first

--- a/spec/api/user_spec.rb
+++ b/spec/api/user_spec.rb
@@ -754,13 +754,30 @@ describe "app" do
         expect(last_response.status).to eq(500)
       end
 
+      it "attempts to retire a user with no subscribed threads" do
+        retired_username = "retired_user_test"
+        post "/api/v1/users/2/retire", retired_username: retired_username
+        expect(last_response).to be_ok
+        # User's comments should be blanked out.
+        user = User.where(external_id: '2').first
+        comments = user.all_comments + user.all_comment_threads
+        expect(comments.count).should_not eq(0)
+        comments.each do |single_comment|
+          if single_comment._type == 'CommentThread'
+            expect(single_comment.title).to match(RETIRED_TITLE)
+          end
+          expect(single_comment.body).to match(RETIRED_BODY)
+          expect(single_comment.author_username).to match(retired_username)
+        end
+      end
+
       it "attempts to retire a non-existent user" do
         post "/api/v1/users/1234/retire", retired_username: "retired_user_test"
         expect(last_response.status).to eq(404)
       end
 
       it "retires a user and all the user's data" do
-        retired_username = "retired_user_ABCD1234"
+        retired_username = "retired_username_ABCD1234"
         user = User.where(external_id: '1').first
         # User should have original username.
         expect(user.username).to eq('user1')
@@ -791,7 +808,8 @@ describe "app" do
         expect(last_response).to be_ok
         expect(JSON.parse(last_response.body)['thread_count']).to eq(0)
         # User's comments should be blanked out.
-        comments = user.all_comments
+        comments = user.all_comments + user.all_comment_threads
+        expect(comments.count).should_not eq(0)
         comments.each do |single_comment|
           if single_comment._type == 'CommentThread'
             expect(single_comment.title).to match(RETIRED_TITLE)

--- a/spec/models/comment_spec.rb
+++ b/spec/models/comment_spec.rb
@@ -120,6 +120,32 @@ describe Comment do
       end
     end
   end
+end
 
+describe 'comment_with_es' do
+  include_context 'search_enabled'
 
+  let(:author) do
+    create_test_user(42)
+  end
+
+  let(:standalone_thread) do
+    make_thread(author, "Test standalone thread", "test_course", "test_commentable", :discussion, :standalone)
+  end
+
+  context 'with search_enabled, updating a comment' do
+    it 'results in ES proxy called' do
+      comment = make_comment(author, standalone_thread, "comment")
+      expect(comment.__elasticsearch__).to receive(:update_document).once.and_call_original
+      comment.update!({body: "changed"})
+    end
+
+    it 'results in ES proxy not called when explicitly disabled' do
+      comment = make_comment(author, standalone_thread, "comment")
+      expect(comment.__elasticsearch__).to_not receive(:update_document).and_call_original
+      comment.enable_es(false)
+      comment.update!({body: "changed"})
+      comment.enable_es(true)
+    end
+  end
 end


### PR DESCRIPTION
This PR backports the user retirement API from Hawthorne and related improvement commits.
The backported commits are:
 * [Add ability to change author_username in content.](https://github.com/edx/cs_comments_service/commit/42fae9159970b3a50e109ee3d37d97f4f86b9287)
 * [Add user retirement API endpoint to remove forum post content.](https://github.com/edx/cs_comments_service/commit/691ac62846ef526bf51dde49ab3abc265e8c09ee)
 * [Shift from deprecated should to expect syntax.](https://github.com/edx/cs_comments_service/commit/24fd748807bbbcc731905746adac024b5e9336a0)
 * [Handle non-existent user and missing param upon retiring user.](https://github.com/edx/cs_comments_service/commit/078c1d3b9f9d70694c2b6a4965388c7a57dbdc8b)
 * [Blank out comment thread documents as well as comment documents.](https://github.com/edx/cs_comments_service/commit/c0c718141a3558a974b634a756d2aabc796b676e)
 * [Add error handling around Elasticsearch update/delete.](https://github.com/edx/cs_comments_service/commit/0e39704298e86e3507b6933762e557e16641dda1)
 * [Process ES updates in bulk during user retirement.](https://github.com/edx/cs_comments_service/commit/7eae611dc7daf295d9e6ca9f48f81903497ba26d)
 * [Make sure ES stays enabled, even if there is an error during update().](https://github.com/edx/cs_comments_service/commit/a8188ad799607e4e4b4c162278ded7c59a96845b)
 * [Avoid sending empty ES bulk requests.](https://github.com/edx/cs_comments_service/commit/6d6770e9ab59fdbadb014f776538d3c57a43ab57)

All of these commits are the implementation of the retirement feature or a improvement related to it.

**Testing:**
1. On your solutions devstack, pull this branch.
2. Create a new user on LMS and enroll in the demonstration course.
3. Create a new discussion and interact with some posts.
4. Delete the user with the backported deletion API
```
curl http://localhost:18080/api/v1/users/1530/retire?retired_username=deleted -X POST -d "" 
```
5. Log in as another user in the LMS and check if the posts and comments were deleted.
6. Inside the vagrant machine of the devstack, check that the mongo table contents have either been deleted on anonymised.
```
$ mongo

> use cs_comments_service
switched to db cs_comments_service

> db.users.find()
...
{ "_id" : "1530", "default_sort_key" : "activity", "external_id" : "1530", "username" : "deleted", "read_states" : [ ], "email" : "" } # Check that username was correctly anonymised

> db.contents.find()
... # You should see a lot of comments with "body"="[deleted]" and "author_username"="deleted".
{ "_id" : ObjectId("5c45ab876362396111525759"), "votes" : { "up" : [ ], "down" : [ ], "up_count" : 0, "down_count" : 0, "count" : 0, "point" : 0 }, "visible" : true, "abuse_flaggers" : [ ], "historical_abuse_flaggers" : [ ], "_type" : "Comment", "parent_ids" : [ ], "at_position_list" : [ ], "body" : "[deleted]", "course_id" : "course-v1:edX+DemoX+Demo_Course", "endorsed" : false, "anonymous" : false, "anonymous_to_peers" : false, "author_id" : "1530", "comment_thread_id" : ObjectId("5c45ab806362396111525757"), "child_count" : 0, "depth" : 0, "author_username" : "deleted", "sk" : "5c45ab876362396111525759", "updated_at" : ISODate("2019-01-21T11:26:01.543Z"), "created_at" : ISODate("2019-01-21T11:22:47.555Z"), "retired_username" : "deleted" }
...
```
**Reviewers:**
- [ ] @jcdyer 
- [ ] EdX Reviewer TBD