### PR TITLE
Adjust deleted message title and body

### DIFF
--- a/models/constants.rb
+++ b/models/constants.rb
@@ -29,5 +29,5 @@ EXTERNAL_ID = "external_id".freeze
 COMMENT = "comment".freeze
 THREAD = "thread".freeze
 
-RETIRED_TITLE = "Deleted message".freeze
-RETIRED_BODY = "Deleted message".freeze
+RETIRED_TITLE = "This message is no longer available".freeze
+RETIRED_BODY = "This message is no longer available".freeze


### PR DESCRIPTION
This PR changes the title and body of retired messages to:
`"This message is no longer available"`

Testing
--------

1. Check out this branch and restart the forum service.
2. Create a test user, enroll in a course that has discussions and create a couple posts and comments.
3. Using an admin user or the shell, retire the forum test user.
4. Check the posts created by the test user and make sure the message was updated.