### PR TITLE
MCKIN-11038 Return 200 when user to retire does not exist

### DIFF
--- a/api/users.rb
+++ b/api/users.rb
@@ -205,7 +205,7 @@ post "#{APIPREFIX}/users/:user_id/retire" do |user_id|
   begin
     user = User.find_by(external_id: user_id)
   rescue Mongoid::Errors::DocumentNotFound
-    error 404, {message: "User not found."}.to_json
+    return {message: "User not found."}.to_json
   end
   user.update_attribute(:email, "")
   user.update_attribute(:notification_ids, [])


### PR DESCRIPTION
Description
=========

Initially the retirement workflow would return a 404 and raise an error when the user to retire was not found. This results in errors being logged when this isn't really an error, as that might happen when an user is created in the LMS and then deleted before logging to the forums.

This change will return an error message but not raise an error in such cases, as no further action is required.

Testing
----------

1. Checkout this branch and restart the forums.
2. Add an user to the LMS and immediately delete it.
3. Make sure no error messages appears in the LMS or forum logs.