### PR TITLE
YONK-1873 - bump version codecov

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
     bson (4.3.0)
     bson_ext (1.5.1)
     builder (3.2.3)
-    codecov (0.1.10)
+    codecov (0.2.11)
       json
       simplecov
       url


### PR DESCRIPTION
This PR has cherry-picked commit from upstream Ironwood release: https://github.com/edx/cs_comments_service/pull/329

Context:
Codecov 0.1.x was yanked from rubygems, causing installation of cs_comments_service to fail. This bumps to the latest codecov version used in open edX Ironwood release
Reference: https://rubygems.org/gems/codecov/versions/0.1.10